### PR TITLE
Fix broken JSONPath for Release Webhook (prod)

### DIFF
--- a/scaffolder-templates/quarkus-stssc-template/manifests/helm/build/templates/triggerbinding-tag-prod.yaml
+++ b/scaffolder-templates/quarkus-stssc-template/manifests/helm/build/templates/triggerbinding-tag-prod.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   params:
     - name: git-repo-url
-      value: $(body.repository.git_http_url)
+      value: $(body.project.git_http_url)
     - name: git-revision
-      value: $(body.after)
+      value: $(body.commit.id)
     - name: source-tag
       value: $(body.tag)
 {{- if ne .Values.image.registry "Quay" }}


### PR DESCRIPTION
## What does this PR do / why we need it
There's no `body.repository` nor `body.after` in the Release Webhook JSON, adding those two existing field with same values

## Which issue(s) does this PR fix

Can't promote app to prod because promote pipeline is never started.

From EventListener pod log:

```
{"severity":"error","timestamp":"2024-06-19T12:35:30.817Z","logger":"eventlistener","caller":"sink/sink.go:438","message":"failed to ApplyEventValuesToParams: failed to replace JSONPath value for param git-repo-url: $(body.repository.git_http_url): repository is not found","commit":"d07613e","eventlistener":"game-secure-el","namespace":"game-secure-dev","/triggers-eventid":"b4689300-14b3-40d9-aa43-21e76609f7b4","eventlistenerUID":"a55ad509-6566-4dc7-a1ec-00db6d003b06","/triggers-eventid":"b4689300-14b3-40d9-aa43-21e76609f7b4","/trigger":"tag-trig-prod"}
```

Fixes #?

## How to test changes / Special notes to the reviewer

Create a new Release in Gitlab to trigger the promotion pipeline
